### PR TITLE
Fix a few deprecation warnings in Xcode

### DIFF
--- a/DOOM3-iOS/Extensions.swift
+++ b/DOOM3-iOS/Extensions.swift
@@ -10,7 +10,6 @@ import Foundation
 extension UIColor {
     convenience init(rgba: String) {
         let scanner = Scanner(string: rgba)
-        scanner.scanLocation = 0
         
         var rgbValue: UInt64 = 0
         

--- a/DOOM3/idlib/Lib.cpp
+++ b/DOOM3/idlib/Lib.cpp
@@ -298,7 +298,7 @@ RESULTS
    Reverses the byte order in each of elcount elements.
 ===================================================================== */
 ID_INLINE static void RevBytesSwap( void *bp, int elsize, int elcount ) {
-	register unsigned char *p, *q;
+	unsigned char *p, *q;
 
 	p = ( unsigned char * ) bp;
 

--- a/DOOM3/idlib/hashing/MD5.cpp
+++ b/DOOM3/idlib/hashing/MD5.cpp
@@ -54,7 +54,7 @@ the data and converts bytes into longwords for this routine.
 =================
 */
 void MD5_Transform( unsigned int state[4], unsigned int in[16] ) {
-	register unsigned int a, b, c, d;
+	unsigned int a, b, c, d;
 
 	a = state[0];
 	b = state[1];

--- a/DOOM3/idlib/math/Simd_Generic.cpp
+++ b/DOOM3/idlib/math/Simd_Generic.cpp
@@ -1815,7 +1815,7 @@ void VPCALL idSIMD_Generic::MatX_LowerTriangularSolve( const idMatX &L, float *x
 	lptr = L[skip];
 
 	int i, j;
-	register double s0, s1, s2, s3;
+	double s0, s1, s2, s3;
 
 	for ( i = skip; i < n; i++ ) {
 		s0 = lptr[0] * x[0];
@@ -1941,7 +1941,7 @@ void VPCALL idSIMD_Generic::MatX_LowerTriangularSolveTranspose( const idMatX &L,
 	}
 
 	int i, j;
-	register double s0, s1, s2, s3;
+	double s0, s1, s2, s3;
 	float *xptr;
 
 	lptr = L.ToFloatPtr() + n * nc + n - 4;

--- a/DOOM3/sys/osx/DOOMController.mm
+++ b/DOOM3/sys/osx/DOOMController.mm
@@ -70,9 +70,9 @@ bool Sys_GetPath(sysPath_t type, idStr &path) {
 	switch(type) {
 	case PATH_BASE:
 #ifdef IOS
-		strncpy(buf, [ [ [ NSBundle mainBundle ] resourcePath ] cString ], MAXPATHLEN );
+		strncpy(buf, [ [ [ NSBundle mainBundle ] resourcePath ] UTF8String ], MAXPATHLEN );
 #else
-        strncpy(buf, [ [ [ NSBundle mainBundle ] bundlePath ] cString ], MAXPATHLEN );
+        strncpy(buf, [ [ [ NSBundle mainBundle ] bundlePath ] UTF8String ], MAXPATHLEN );
 
         snap = strrchr(buf, '/');
 		if (snap)

--- a/DOOM3/sys/osx/macosx_misc.mm
+++ b/DOOM3/sys/osx/macosx_misc.mm
@@ -77,5 +77,5 @@ const char* OSX_GetLocalizedString( const char* key )
 {
 	NSString *string = [ [ NSBundle mainBundle ] localizedStringForKey:[ NSString stringWithCString: key ]
 													 value:@"No translation" table:nil];
-	return [string cString];
+	return [string UTF8String];
 }

--- a/DOOM3/sys/osx/macosx_misc.mm
+++ b/DOOM3/sys/osx/macosx_misc.mm
@@ -51,7 +51,7 @@ void idSysLocal::OpenURL( const char *url, bool doexit ) {
 
 
 	[[ UIApplication sharedApplication] openURL: [ NSURL URLWithString:
-		[ NSString stringWithCString: url ] ] ];
+		[ NSString stringWithUTF8String: url ] ] ];
 
 	if ( doexit ) {
 		quit_spamguard = true;
@@ -75,7 +75,7 @@ OSX_GetLocalizedString
 */
 const char* OSX_GetLocalizedString( const char* key )
 {
-	NSString *string = [ [ NSBundle mainBundle ] localizedStringForKey:[ NSString stringWithCString: key ]
+	NSString *string = [ [ NSBundle mainBundle ] localizedStringForKey:[ NSString stringWithUTF8String: key ]
 													 value:@"No translation" table:nil];
 	return [string UTF8String];
 }

--- a/DOOM3/tools/compilers/roqvq/codec.cpp
+++ b/DOOM3/tools/compilers/roqvq/codec.cpp
@@ -750,7 +750,7 @@ void codec::IRGBtab(void)
 float codec::Snr( byte *old, byte *bnew, int size ) {
 int i, j;
 float fsnr;
-register int ind;
+int ind;
 
 	ind = 0;
 


### PR DESCRIPTION
Removed a usage of scanLocation, which was deprecated in iOS 13. It seems that setting the scan location to 0 when creating a scanner is not required, so I just deleted the line. 

cString was deprecated in iOS 2, so I replaced with UTF8String in two places. Seems to be working OK. 

Edit: Also changed stringWithCString to stringWithUTF8String for the same reason. 

Also removed the register keyword. Deprecated in C++11 and removed in C++17 and according to the following stack overflow page wasn't really used anyway. There is no replacement for it. 

https://stackoverflow.com/questions/20618008/replacement-for-deprecated-register-keyword-c-11