### PR TITLE
Add short bundle version string

### DIFF
--- a/DOOM3-iOS/DOOM3xp-Info.plist
+++ b/DOOM3-iOS/DOOM3xp-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This pull request adds the `CFBundleShortVersionString ` key from the `DOOM3-Info.plist` file to prevent errors in the Simulator.